### PR TITLE
Binding external functions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+scratch.py

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 ![Lines of code](https://img.shields.io/tokei/lines/github/pseeth/argbind)
 [![Downloads](https://pepy.tech/badge/argbind)](https://pepy.tech/project/argbind)
 
-*ArgBind is a simple way to bind arguments to functions to the command line or to .yml files!* It supports scoping of arguments, similar to other frameworks like 
+*ArgBind is a simple way to bind function or class arguments to the command line or to .yml files!* 
+It supports scoping of arguments, similar to other frameworks like 
 [Hydra](https://github.com/facebookresearch/hydra) and
 [gin-config](https://github.com/google/gin-config).
 ArgBind is *very* small (only ~400 lines of code, in one file), can be used to make complex and well-documented command line programs, and allows 
@@ -61,14 +62,15 @@ python -m pip install -e .
 - [Example 6: Multi-stage programs](./examples/multistage)
 - [Example 7: Mimic more traditional CLI, without `func.arg` notation](./examples/without_prefix)
 - [Example 8: Debug mode](./examples/debug)
-- [Example 8: Migrating from ArgParse](./examples/migration)
+- [Example 9: Migrating from ArgParse](./examples/migration)
+- [Example 10: Binding existing functions and classes](./examples/bind_existing)
 
 ## Usage
 
 There are six main functions.
 
-- `bind`: Binds a functions typed keyword arguments (and positional arguments if `positional=True`) to ArgBind.
-- `parse_args`: Actually parses the arguments into a dictionary.
+- `bind`: Binds typed keyword arguments (and positional arguments if `positional=True`) of a function or class to ArgBind.
+- `parse_args`: Actually parses command line arguments into a dictionary.
 - `scope`: Context manager that scopes a dictionary containing function arguments to be used by the functions.
 - `dump_args`: Dumps the args dictionary to a `.yml` file. Used internally when program is called with `--args.save path/to/save.yml`.
 - `load_args`: Loads args from a `.yml` file. Used internally when program is called with `--args.load path/to/load.yml`.
@@ -241,6 +243,8 @@ The logic here is that arguments that are bound that are closer to the actual fu
 2. Bound via command line
 3. Bound via .yml file
 4. Bound via default for kwarg
+
+You can also use `bind` directly on classes - see [here](./examples/bind_existing).
 
 ### Note!
 

--- a/argbind/argbind.py
+++ b/argbind/argbind.py
@@ -60,12 +60,17 @@ def _format_func_debug(func_name, func_kwargs, scope=None):
     formatted.append(")")
     return '\n'.join(formatted)
 
-def bind(*patterns, without_prefix=False, positional=False):
+def bind(*args, without_prefix=False, positional=False):
     """Binds a functions arguments so that it looks up argument
     values in a dictionary scoped by ArgBind.
 
     Parameters
     ----------
+    args : List[str] or [fn or Object] + List[str], optional
+        List of patterns to bind the function under. If the first item
+        in the list is a function or Object, then the function is bound
+        here (e.g. decorate is called on the first argument). Otherwise,
+        it is treated is a decorator.
     without_prefix : bool, optional
         Whether or not to bind without the function name as the prefix. 
         If True, the functions arguments will be available at "arg_name"
@@ -75,6 +80,13 @@ def bind(*patterns, without_prefix=False, positional=False):
         this is True, then the arguments will be bound as positional arguments
         in some order, by default False
     """
+
+    if args and not isinstance(args[0], str):
+        bound_fn_or_cls = args[0]
+        patterns = args[1:] if len(args) > 1 else []
+    else:
+        bound_fn_or_cls = None
+        patterns = args
 
     if positional and patterns:
         warnings.warn(
@@ -113,8 +125,11 @@ def bind(*patterns, without_prefix=False, positional=False):
                 print(_format_func_debug(prefix, kwargs, scope))
             return func(*args, **kwargs)
         return cmd_func
-    
-    return decorator
+
+    if bound_fn_or_cls is None:
+        return decorator
+    else:
+        return decorator(bound_fn_or_cls)
 
 # Backwards compat.
 # For scripts written with argbind<=0.1.3.

--- a/examples/bind_existing/README.md
+++ b/examples/bind_existing/README.md
@@ -1,0 +1,122 @@
+# Binding existing functions or classes
+
+ArgBind can be used to bind functions that already exist in other packages,
+provided that the function's arguments are *typed*. Function arguments must be typed
+so that ArgBind knows how to parse the command line before passing arguments
+to the function. Other limitations as laid out in the ArgBind README also apply.
+
+## How to use it
+
+Let's say I have some module where the following objects are defined:
+
+```python
+# contents of my_module.py
+class MyClass:
+    def __init__(self, x: str = "from default"):
+        self.x = x
+
+def my_func(x: int = 100):
+    print(x)
+    return x
+```
+
+Obviously, the creator of this package isn't using ArgBind anywhere, but
+since the objects are already defined, we can't decorate them with the
+`@` syntax. So, we should do this instead:
+
+```python
+import argbind
+
+BoundClass = argbind.bind(MyClass)
+bound_fn = argbind.bind(my_func)
+```
+
+Now when you call either `BoundClass` or `bound_fn`, you get the "ArgBind'ed" version
+of those functions. If you call `MyClass` or `my_func` instead, you'll get the original
+functions - undecorated, which won't have any ArgBindiness associated with them. 
+They are just the original functions, as defined in the module.
+
+If you want to bind it within some scoping patterns, then you just do this:
+
+```python
+BoundClass = argbind.bind(MyClass, 'train')
+bound_fn = argbind.bind(my_func, 'train')
+```
+
+Let's look at a complete example:
+
+```python
+# Functions/classes that should be bound
+class MyClass:
+    def __init__(self, x: str = "from default"):
+        self.x = x
+        print(self.x)
+
+def my_func(x: int = 100):
+    print(x)
+    return x
+
+if __name__ == "__main__":
+    import argbind
+    
+    BoundClass = argbind.bind(MyClass, 'pattern')
+    bound_fn = argbind.bind(my_func)
+
+    args = {
+      'MyClass.x': 'from binding',
+      'pattern/MyClass.x': 'from binding in scoping pattern',
+      'my_func.x': 123,
+      'args.debug': True # for printing arguments passed to each function
+    }
+
+    # Original objects are not affected by ArgBind
+    print("Original object output")
+    with argbind.scope(args):
+        MyClass() # prints "from default"
+        my_func() # prints 100
+    print()
+    
+    # Bound objects ARE affected by ArgBind
+    print("Bound objects output")
+    with argbind.scope(args):
+        BoundClass() # prints "from binding"
+        bound_fn() # prints 123
+    print()
+    
+    # Scoping patterns can be used
+    print("Bound objects inside scoping pattern output")
+    with argbind.scope(args, 'pattern'):
+        BoundClass() # prints "from binding in scoping pattern"
+        bound_fn() # still prints 123
+```
+
+This has the following output:
+
+```bash
+❯ python examples/bind_existing/with_argbind.py
+Original object output
+from default
+100
+
+Bound objects output
+MyClass(
+  x : str = from binding
+)
+from binding
+my_func(
+  x : int = 123
+)
+123
+
+Bound objects inside scoping pattern output
+MyClass(
+  # scope = pattern
+  x : str = from binding in scoping pattern
+)
+from binding in scoping pattern
+my_func(
+  # scope = pattern
+  x : int = 123
+)
+123
+```

--- a/examples/bind_existing/with_argbind.py
+++ b/examples/bind_existing/with_argbind.py
@@ -1,0 +1,43 @@
+# Functions/classes that should be bound
+class MyClass:
+    def __init__(self, x: str = "from default"):
+        self.x = x
+        print(self.x)
+
+def my_func(x: int = 100):
+    print(x)
+    return x
+
+if __name__ == "__main__":
+    import argbind
+    
+    BoundClass = argbind.bind(MyClass, 'pattern')
+    bound_fn = argbind.bind(my_func)
+
+    args = {
+      'MyClass.x': 'from binding',
+      'pattern/MyClass.x': 'from binding in scoping pattern',
+      'my_func.x': 123,
+      'args.debug': True # for printing arguments passed to each function
+    }
+
+    # Original objects are not affected by ArgBind
+    print("Original object output")
+    with argbind.scope(args):
+        MyClass() # prints "from default"
+        my_func() # prints 100
+    print()
+    
+    # Bound objects ARE affected by ArgBind
+    print("Bound objects output")
+    with argbind.scope(args):
+        BoundClass() # prints "from binding"
+        bound_fn() # prints 123
+    print()
+    
+    # Scoping patterns can be used
+    print("Bound objects inside scoping pattern output")
+    with argbind.scope(args, 'pattern'):
+        BoundClass() # prints "from binding in scoping pattern"
+        bound_fn() # still prints 123
+        

--- a/examples/bind_existing/with_argbind.py
+++ b/examples/bind_existing/with_argbind.py
@@ -14,6 +14,8 @@ if __name__ == "__main__":
     BoundClass = argbind.bind(MyClass, 'pattern')
     bound_fn = argbind.bind(my_func)
 
+    argbind.parse_args() # add for help text, though it isn't used here.
+
     args = {
       'MyClass.x': 'from binding',
       'pattern/MyClass.x': 'from binding in scoping pattern',
@@ -40,4 +42,3 @@ if __name__ == "__main__":
     with argbind.scope(args, 'pattern'):
         BoundClass() # prints "from binding in scoping pattern"
         bound_fn() # still prints 123
-        

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 setup(
     name='argbind',
-    version='0.2.0', 
+    version='0.3.0', 
     description='Simple way to bind function arguments to the command line.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/regression/bind_existing/with_argbind.py.help
+++ b/tests/regression/bind_existing/with_argbind.py.help
@@ -1,0 +1,25 @@
+Original object output
+from default
+100
+
+Bound objects output
+MyClass(
+  x : str = from binding
+)
+from binding
+my_func(
+  x : int = 123
+)
+123
+
+Bound objects inside scoping pattern output
+MyClass(
+  # scope = pattern
+  x : str = from binding in scoping pattern
+)
+from binding in scoping pattern
+my_func(
+  # scope = pattern
+  x : int = 123
+)
+123

--- a/tests/regression/bind_existing/with_argbind.py.help
+++ b/tests/regression/bind_existing/with_argbind.py.help
@@ -1,25 +1,23 @@
-Original object output
-from default
-100
+usage: with_argbind.py [-h] [--args.save ARGS.SAVE] [--args.load ARGS.LOAD]
+                       [--args.debug ARGS.DEBUG] [--MyClass.x MYCLASS.X]
+                       [--my_func.x MY_FUNC.X]
 
-Bound objects output
-MyClass(
-  x : str = from binding
-)
-from binding
-my_func(
-  x : int = 123
-)
-123
+optional arguments:
+  -h, --help            show this help message and exit
+  --args.save ARGS.SAVE
+                        Path to save all arguments used to run script to.
+  --args.load ARGS.LOAD
+                        Path to load arguments from, stored as a .yml file.
+  --args.debug ARGS.DEBUG
+                        Print arguments as they are passed to each function.
 
-Bound objects inside scoping pattern output
-MyClass(
-  # scope = pattern
-  x : str = from binding in scoping pattern
-)
-from binding in scoping pattern
-my_func(
-  # scope = pattern
-  x : int = 123
-)
-123
+Generated arguments for function MyClass:
+   Additional scope patterns: pattern. Use these by prefacing
+  any of the args below with one of these patterns. For
+  example: --pattern/MyClass.x VALUE.
+
+  --MyClass.x MYCLASS.X
+
+Generated arguments for function my_func:
+
+  --my_func.x MY_FUNC.X

--- a/tests/regression/bind_existing/with_argbind.py.run
+++ b/tests/regression/bind_existing/with_argbind.py.run
@@ -1,0 +1,25 @@
+Original object output
+from default
+100
+
+Bound objects output
+MyClass(
+  x : str = from binding
+)
+from binding
+my_func(
+  x : int = 123
+)
+123
+
+Bound objects inside scoping pattern output
+MyClass(
+  # scope = pattern
+  x : str = from binding in scoping pattern
+)
+from binding in scoping pattern
+my_func(
+  # scope = pattern
+  x : int = 123
+)
+123


### PR DESCRIPTION
The signature of `bind` changes in this PR in a backwards compatible way.  The first argument to `bind` can now be a Python callable:  a function or a class. If it is, then `bind` calls the decorator on the first argument and returns it. It's basically syntactic sugar that turns code proposed in #4:

```
import argbind
from somewhere import SomeClass

BoundClass = argbind.bind()(SomeClass)
```

into:

```
import argbind
from somewhere import SomeClass

BoundClass = argbind.bind(SomeClass)
```

When you call `BoundClass` you get a version of the original function that is bound by ArgBind, and thus has its arguments injected by it if called under some scope. A full example is added in this PR of this functionality.