### PR TITLE
Adding `bind_module`, removing typing requirement for kwargs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ python -m pip install -e .
 
 There are six main functions.
 
-- `bind`: Binds typed keyword arguments (and positional arguments if `positional=True`) of a function or class to ArgBind.
+- `bind`: Binds keyword arguments (and positional arguments if `positional=True`) of a function or class to ArgBind.
 - `parse_args`: Actually parses command line arguments into a dictionary.
 - `scope`: Context manager that scopes a dictionary containing function arguments to be used by the functions.
 - `dump_args`: Dumps the args dictionary to a `.yml` file. Used internally when program is called with `--args.save path/to/save.yml`.
@@ -78,7 +78,7 @@ There are six main functions.
 
 Your code with ArgBind generally follows this pattern:
 
-1. Write a function with a good docstring, and typed arguments.
+1. Write a function with a good docstring, and typed arguments. If arguments are not typed, their type will be inferred from the type of the default.
 2. Bind it via `bind`.
 3. When program is called, parse the arguments via `parse_args`.
 4. Scope the arguments, and call the bound function within the context block.
@@ -186,7 +186,7 @@ Please check out the [examples](#examples) for more details!
 
 ArgBind is designed around a decorator that can be used on
 functions the user wants to expose to command line or to a .yml file.
-The typed arguments to that function are 
+The arguments to that function are 
 then bound to a dictionary. When the function is called, 
 each argument is looked up in the dictionary and its
 value is replaced with the corresponding value in the dictionary. The
@@ -246,12 +246,6 @@ The logic here is that arguments that are bound that are closer to the actual fu
 
 You can also use `bind` directly on classes - see [here](./examples/bind_existing).
 
-### Note!
-
-The catch is that the function's argument MUST be typed.
-This is required so that ArgBind knows how to parse it from the
-command line.
-
 # Limitations and known issues
 
 There are some limitations to ArgBind, some due to how Python function decorator works,
@@ -264,13 +258,6 @@ way to override it from the command line. If you want a flag to
 be flippable, make the argument an int instead of a bool and use
 0 and 1 for True and False. Then you can override from command
 line like `--func.arg 0` or `--func.arg 1`.
-
-## Only typed arguments are bound
-
-Only keyword arguments that have types associated with them are bound 
-in functions. Positional arguments are bound only if `positional=True`. 
-Untyped arguments cannot be bound, because ArgBind won't know what type to 
-parse for.
 
 ## Bound function names should be unique
 

--- a/argbind/__init__.py
+++ b/argbind/__init__.py
@@ -1,6 +1,7 @@
 from .argbind import (
     bind, 
     bind_to_parser, # For backwards compat.
+    bind_module,
     parse_args,
     dump_args,
     load_args,

--- a/argbind/argbind.py
+++ b/argbind/argbind.py
@@ -145,9 +145,15 @@ class bind_module:
         ----------
         module : ModuleType
             Module or object whose attributes to bind.
-        recursive : bool, optional
-            Whether to recursively apply the binding to submodules of the
-            specified module, by default False
+        scopes : List[str] or [fn or Object] + List[str], optional
+            List of patterns to bind the function under.
+        filter_fn : Callable, optional
+            A function that takes in the function that is to be bound, and 
+            returns a boolean as to whether or not it should be bound.
+            Defaults to always True, no matter what the function is.
+        kwargs : keyword arguments, optional
+            Keyword arguments to the bind function.
+
         """
         for fn_name in dir(module):
             fn = getattr(module, fn_name)

--- a/argbind/argbind.py
+++ b/argbind/argbind.py
@@ -1,7 +1,7 @@
 import inspect
 from contextlib import contextmanager
 import argparse
-from typing import List, Dict, Tuple
+from typing import List, Dict
 import docstring_parser
 import textwrap
 import yaml
@@ -134,6 +134,27 @@ def bind(*args, without_prefix=False, positional=False):
 # Backwards compat.
 # For scripts written with argbind<=0.1.3.
 bind_to_parser = bind
+
+class bind_module:
+    def __init__(self, module, *scopes, filter_fn=lambda fn: True, **kwargs):
+        """Binds every function/class in a specified module. The output
+        class is a bound version of the original module, with the 
+        attributes in the same place.
+
+        Parameters
+        ----------
+        module : ModuleType
+            Module or object whose attributes to bind.
+        recursive : bool, optional
+            Whether to recursively apply the binding to submodules of the
+            specified module, by default False
+        """
+        for fn_name in dir(module):
+            fn = getattr(module, fn_name)
+            if not isinstance(fn, type(sys)) and hasattr(fn, "__name__"):
+                if filter_fn(fn):
+                    bound_fn = bind(fn, *scopes, **kwargs)
+                    setattr(self, fn_name, bound_fn)
 
 def get_used_args():
     """
@@ -306,9 +327,12 @@ def parse_args():
 
 
         for key, val in sig.parameters.items():
-            arg_type = val.annotation
             arg_val = val.default
+            arg_type = val.annotation
             is_kwarg = arg_val is not inspect.Parameter.empty
+
+            if arg_type is inspect.Parameter.empty and is_kwarg:
+                arg_type = type(arg_val)
 
             if is_kwarg or positional:
                 arg_names = _get_arg_names(key, is_kwarg)

--- a/examples/bind_module/README.md
+++ b/examples/bind_module/README.md
@@ -1,0 +1,97 @@
+# Binding a module
+
+ArgBind allows you bind an entire module, giving back an object that
+behaves similarly to the original module, but has all of the
+sub-modules and functions bound to the parser. This is useful if
+you're working with a big package, but don't want to sprinkle the package
+code with decorators for all the functions you care about. Instead, one can
+do it all at once and get a package with everything bound as needed.
+
+Let's start by using ArgBind to bind all the methods in `torch.optim`:
+
+```python
+import torch
+import argbind
+
+optim = argbind.bind_module(
+    torch.optim, 
+    filter_fn=lambda fn: hasattr(fn, "step")
+)
+args = {
+    "lr": 2e-4,
+    "args.debug": True,
+}
+
+net = torch.nn.Linear(1, 1)
+for fn_name in dir(optim):
+    if fn_name.startswith("_") or fn_name == "Optimizer":
+        continue
+    fn = getattr(optim, fn_name)
+    args[f"{fn_name}.lr"] = args["lr"]
+    with argbind.scope(args):
+        fn(net.parameters())
+```
+
+A few things to note, `bind_module` takes (optionally) a `filter_fn`, 
+which takes in the object, and returns a bool which indicates whether
+or not it should be bound. You can use this to filter out any functions
+or classes that you don't want bound. Here we use it to bind only
+classes which have a `step` attribute (these are the optimizers).
+
+Then we just write our script normally like any other ArgBind script.
+
+**N.B.: `bind_module` only goes ONE level deep. It does not recursively apply
+itself to bind submodules. This could happen in the future, but the 
+logic must be done carefully to avoid loops cause by circular imports.**
+
+For comparison, here is how the code would look without binding
+the entire module, to achieve the same output:
+
+```python
+import torch
+import argbind
+
+# Binding all the optimizers
+ASGD = argbind.bind(torch.optim.ASGD)
+Adadelta = argbind.bind(torch.optim.Adadelta)
+Adagrad = argbind.bind(torch.optim.Adagrad)
+AdamW = argbind.bind(torch.optim.AdamW)
+Adamax = argbind.bind(torch.optim.Adamax)
+LBFGS = argbind.bind(torch.optim.LBFGS)
+NAdam = argbind.bind(torch.optim.NAdam)
+RAdam = argbind.bind(torch.optim.RAdam)
+RMSprop = argbind.bind(torch.optim.RMSprop)
+Rprop = argbind.bind(torch.optim.Rprop)
+SGD = argbind.bind(torch.optim.SGD)
+SparseAdam = argbind.bind(torch.optim.SparseAdam)
+
+optimizers = [
+    ASGD, Adadelta, Adagrad, AdamW, Adamax, LBFGS,
+    NAdam, RAdam, RMSprop, Rprop, SGD, SparseAdam
+]
+
+class holder:
+    def __init__(self):
+        for o in optimizers:
+            setattr(self, o.__name__, o)
+optim = holder()
+
+args = {
+    "lr": 2e-4,
+    "args.debug": True,
+}
+
+net = torch.nn.Linear(1, 1)
+
+for fn_name in dir(optim):
+    if fn_name == "Optimizer":
+        continue
+    fn = getattr(optim, fn_name)
+    if hasattr(fn, "step"):
+        args[f"{fn_name}.lr"] = args["lr"]
+        with argbind.scope(args):
+            fn(net.parameters())
+```
+
+In this script, every single function must be bound one by one, which
+is rather tedious. `bind_module` is more succinct.

--- a/examples/bind_module/bind_module.py
+++ b/examples/bind_module/bind_module.py
@@ -10,11 +10,14 @@ args = {
     "args.debug": True,
 }
 
-net = torch.nn.Linear(1, 1)
-for fn_name in dir(optim):
-    if fn_name.startswith("_") or fn_name == "Optimizer":
-        continue
-    fn = getattr(optim, fn_name)
-    args[f"{fn_name}.lr"] = args["lr"]
-    with argbind.scope(args):
-        fn(net.parameters())
+if __name__ == "__main__":
+    argbind.parse_args()
+    
+    net = torch.nn.Linear(1, 1)
+    for fn_name in dir(optim):
+        if fn_name.startswith("_") or fn_name == "Optimizer":
+            continue
+        fn = getattr(optim, fn_name)
+        args[f"{fn_name}.lr"] = args["lr"]
+        with argbind.scope(args):
+            fn(net.parameters())

--- a/examples/bind_module/bind_module.py
+++ b/examples/bind_module/bind_module.py
@@ -1,0 +1,20 @@
+import torch
+import argbind
+
+optim = argbind.bind_module(
+    torch.optim, 
+    filter_fn=lambda fn: hasattr(fn, "step")
+)
+args = {
+    "lr": 2e-4,
+    "args.debug": True,
+}
+
+net = torch.nn.Linear(1, 1)
+for fn_name in dir(optim):
+    if fn_name.startswith("_") or fn_name == "Optimizer":
+        continue
+    fn = getattr(optim, fn_name)
+    args[f"{fn_name}.lr"] = args["lr"]
+    with argbind.scope(args):
+        fn(net.parameters())

--- a/examples/bind_module/without_bind_module.py
+++ b/examples/bind_module/without_bind_module.py
@@ -1,0 +1,43 @@
+import torch
+import argbind
+
+# Binding all the optimizers
+ASGD = argbind.bind(torch.optim.ASGD)
+Adadelta = argbind.bind(torch.optim.Adadelta)
+Adagrad = argbind.bind(torch.optim.Adagrad)
+AdamW = argbind.bind(torch.optim.AdamW)
+Adamax = argbind.bind(torch.optim.Adamax)
+LBFGS = argbind.bind(torch.optim.LBFGS)
+NAdam = argbind.bind(torch.optim.NAdam)
+RAdam = argbind.bind(torch.optim.RAdam)
+RMSprop = argbind.bind(torch.optim.RMSprop)
+Rprop = argbind.bind(torch.optim.Rprop)
+SGD = argbind.bind(torch.optim.SGD)
+SparseAdam = argbind.bind(torch.optim.SparseAdam)
+
+optimizers = [
+    ASGD, Adadelta, Adagrad, AdamW, Adamax, LBFGS,
+    NAdam, RAdam, RMSprop, Rprop, SGD, SparseAdam
+]
+
+class holder:
+    def __init__(self):
+        for o in optimizers:
+            setattr(self, o.__name__, o)
+optim = holder()
+
+args = {
+    "lr": 2e-4,
+    "args.debug": True,
+}
+
+net = torch.nn.Linear(1, 1)
+
+for fn_name in dir(optim):
+    if fn_name == "Optimizer":
+        continue
+    fn = getattr(optim, fn_name)
+    if hasattr(fn, "step"):
+        args[f"{fn_name}.lr"] = args["lr"]
+        with argbind.scope(args):
+            fn(net.parameters())

--- a/examples/bind_module/without_bind_module.py
+++ b/examples/bind_module/without_bind_module.py
@@ -31,13 +31,16 @@ args = {
     "args.debug": True,
 }
 
-net = torch.nn.Linear(1, 1)
+if __name__ == "__main__":
+    argbind.parse_args()
+    
+    net = torch.nn.Linear(1, 1)
+    for fn_name in dir(optim):
+        if fn_name == "Optimizer":
+            continue
+        fn = getattr(optim, fn_name)
+        if hasattr(fn, "step"):
+            args[f"{fn_name}.lr"] = args["lr"]
+            with argbind.scope(args):
+                fn(net.parameters())
 
-for fn_name in dir(optim):
-    if fn_name == "Optimizer":
-        continue
-    fn = getattr(optim, fn_name)
-    if hasattr(fn, "step"):
-        args[f"{fn_name}.lr"] = args["lr"]
-        with argbind.scope(args):
-            fn(net.parameters())

--- a/examples/typing/README.md
+++ b/examples/typing/README.md
@@ -2,7 +2,7 @@
 
 ArgBind figures out how to parse things from the command line using
 Python Type Hinting. This means that the functions that you bind
-from your function *must* be strongly typed in the function
+from your function should ideally be typed in the function
 signature. The following types are supported:
 
 - Strings
@@ -16,6 +16,8 @@ signature. The following types are supported:
     - Passed in as flags from command line, like `--func.bool_arg`, which will set it to True. Make the default False.
 - Tuples
     - Tuples must be strongly typed, with each entry in the expected tuple typed, like this `Tuple[int, float, str]`.
+
+If typehints are not available, the type will be inferred by using the type of the default.
 
 ## Example
 

--- a/examples/typing/with_argbind.py
+++ b/examples/typing/with_argbind.py
@@ -3,7 +3,7 @@ from typing import List, Dict, Tuple
 
 @argbind.bind()
 def func(
-    str_arg : str = 'string',
+    str_arg = 'string',
     int_arg : int = 1,
     dict_arg : Dict = None,
     list_int_arg : List[int] = None,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 setup(
     name='argbind',
-    version='0.3.0', 
+    version='0.3.1', 
     description='Simple way to bind function arguments to the command line.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/regression/bind_module/bind_module.py.help
+++ b/tests/regression/bind_module/bind_module.py.help
@@ -1,39 +1,267 @@
-ASGD(
-  lr : float = 0.0002
-)
-Adadelta(
-  lr : float = 0.0002
-)
-Adagrad(
-  lr : float = 0.0002
-)
-Adam(
-  lr : float = 0.0002
-)
-AdamW(
-  lr : float = 0.0002
-)
-Adamax(
-  lr : float = 0.0002
-)
-LBFGS(
-  lr : float = 0.0002
-)
-NAdam(
-  lr : float = 0.0002
-)
-RAdam(
-  lr : float = 0.0002
-)
-RMSprop(
-  lr : float = 0.0002
-)
-Rprop(
-  lr : float = 0.0002
-)
-SGD(
-  lr : float = 0.0002
-)
-SparseAdam(
-  lr : float = 0.0002
-)
+usage: bind_module.py [-h] [--args.save ARGS.SAVE] [--args.load ARGS.LOAD]
+                      [--args.debug ARGS.DEBUG] [--ASGD.lr ASGD.LR]
+                      [--ASGD.lambd ASGD.LAMBD] [--ASGD.alpha ASGD.ALPHA]
+                      [--ASGD.t0 ASGD.T0]
+                      [--ASGD.weight_decay ASGD.WEIGHT_DECAY]
+                      [--Adadelta.lr ADADELTA.LR]
+                      [--Adadelta.rho ADADELTA.RHO]
+                      [--Adadelta.eps ADADELTA.EPS]
+                      [--Adadelta.weight_decay ADADELTA.WEIGHT_DECAY]
+                      [--Adagrad.lr ADAGRAD.LR]
+                      [--Adagrad.lr_decay ADAGRAD.LR_DECAY]
+                      [--Adagrad.weight_decay ADAGRAD.WEIGHT_DECAY]
+                      [--Adagrad.initial_accumulator_value ADAGRAD.INITIAL_ACCUMULATOR_VALUE]
+                      [--Adagrad.eps ADAGRAD.EPS] [--Adam.lr ADAM.LR]
+                      [--Adam.betas ADAM.BETAS] [--Adam.eps ADAM.EPS]
+                      [--Adam.weight_decay ADAM.WEIGHT_DECAY] [--Adam.amsgrad]
+                      [--Adam.maximize] [--AdamW.lr ADAMW.LR]
+                      [--AdamW.betas ADAMW.BETAS] [--AdamW.eps ADAMW.EPS]
+                      [--AdamW.weight_decay ADAMW.WEIGHT_DECAY]
+                      [--AdamW.amsgrad] [--AdamW.maximize]
+                      [--Adamax.lr ADAMAX.LR] [--Adamax.betas ADAMAX.BETAS]
+                      [--Adamax.eps ADAMAX.EPS]
+                      [--Adamax.weight_decay ADAMAX.WEIGHT_DECAY]
+                      [--LBFGS.lr LBFGS.LR] [--LBFGS.max_iter LBFGS.MAX_ITER]
+                      [--LBFGS.max_eval LBFGS.MAX_EVAL]
+                      [--LBFGS.tolerance_grad LBFGS.TOLERANCE_GRAD]
+                      [--LBFGS.tolerance_change LBFGS.TOLERANCE_CHANGE]
+                      [--LBFGS.history_size LBFGS.HISTORY_SIZE]
+                      [--LBFGS.line_search_fn LBFGS.LINE_SEARCH_FN]
+                      [--NAdam.lr NADAM.LR] [--NAdam.betas NADAM.BETAS]
+                      [--NAdam.eps NADAM.EPS]
+                      [--NAdam.weight_decay NADAM.WEIGHT_DECAY]
+                      [--NAdam.momentum_decay NADAM.MOMENTUM_DECAY]
+                      [--RAdam.lr RADAM.LR] [--RAdam.betas RADAM.BETAS]
+                      [--RAdam.eps RADAM.EPS]
+                      [--RAdam.weight_decay RADAM.WEIGHT_DECAY]
+                      [--RMSprop.lr RMSPROP.LR]
+                      [--RMSprop.alpha RMSPROP.ALPHA]
+                      [--RMSprop.eps RMSPROP.EPS]
+                      [--RMSprop.weight_decay RMSPROP.WEIGHT_DECAY]
+                      [--RMSprop.momentum RMSPROP.MOMENTUM]
+                      [--RMSprop.centered] [--Rprop.lr RPROP.LR]
+                      [--Rprop.etas RPROP.ETAS]
+                      [--Rprop.step_sizes RPROP.STEP_SIZES] [--SGD.lr SGD.LR]
+                      [--SGD.momentum SGD.MOMENTUM]
+                      [--SGD.dampening SGD.DAMPENING]
+                      [--SGD.weight_decay SGD.WEIGHT_DECAY] [--SGD.nesterov]
+                      [--SGD.maximize] [--SparseAdam.lr SPARSEADAM.LR]
+                      [--SparseAdam.betas SPARSEADAM.BETAS]
+                      [--SparseAdam.eps SPARSEADAM.EPS]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --args.save ARGS.SAVE
+                        Path to save all arguments used to run script to.
+  --args.load ARGS.LOAD
+                        Path to load arguments from, stored as a .yml file.
+  --args.debug ARGS.DEBUG
+                        Print arguments as they are passed to each function.
+
+Generated arguments for function ASGD:
+  Implements Averaged Stochastic Gradient Descent.
+
+  --ASGD.lr ASGD.LR     learning rate (default: 1e-2)
+  --ASGD.lambd ASGD.LAMBD
+                        decay term (default: 1e-4)
+  --ASGD.alpha ASGD.ALPHA
+                        power for eta update (default: 0.75)
+  --ASGD.t0 ASGD.T0     point at which to start averaging (default: 1e6)
+  --ASGD.weight_decay ASGD.WEIGHT_DECAY
+                        weight decay (L2 penalty) (default: 0) .. _Acceleration of
+                        stochastic approximation by averaging:
+
+Generated arguments for function Adadelta:
+  Implements Adadelta algorithm.
+
+  --Adadelta.lr ADADELTA.LR
+                        coefficient that scale delta before it is applied to the
+                        parameters (default: 1.0)
+  --Adadelta.rho ADADELTA.RHO
+                        coefficient used for computing a running average of squared
+                        gradients (default: 0.9)
+  --Adadelta.eps ADADELTA.EPS
+                        term added to the denominator to improve numerical stability
+                        (default: 1e-6)
+  --Adadelta.weight_decay ADADELTA.WEIGHT_DECAY
+                        weight decay (L2 penalty) (default: 0) .. _ADADELTA\: An
+                        Adaptive Learning Rate Method:
+
+Generated arguments for function Adagrad:
+  Implements Adagrad algorithm.
+
+  --Adagrad.lr ADAGRAD.LR
+                        learning rate (default: 1e-2)
+  --Adagrad.lr_decay ADAGRAD.LR_DECAY
+                        learning rate decay (default: 0)
+  --Adagrad.weight_decay ADAGRAD.WEIGHT_DECAY
+                        weight decay (L2 penalty) (default: 0)
+  --Adagrad.initial_accumulator_value ADAGRAD.INITIAL_ACCUMULATOR_VALUE
+  --Adagrad.eps ADAGRAD.EPS
+                        term added to the denominator to improve numerical stability
+                        (default: 1e-10)  .. _Adaptive Subgradient Methods for
+                        Online Learning and Stochastic
+
+Generated arguments for function Adam:
+  Implements Adam algorithm.
+
+  --Adam.lr ADAM.LR     learning rate (default: 1e-3)
+  --Adam.betas ADAM.BETAS
+                        coefficients used for computing running averages of gradient
+                        and its square (default: (0.9, 0.999))
+  --Adam.eps ADAM.EPS   term added to the denominator to improve numerical stability
+                        (default: 1e-8)
+  --Adam.weight_decay ADAM.WEIGHT_DECAY
+                        weight decay (L2 penalty) (default: 0)
+  --Adam.amsgrad        whether to use the AMSGrad variant of this algorithm from
+                        the paper `On the Convergence of Adam and Beyond`_ (default:
+                        False)
+  --Adam.maximize       maximize the params based on the objective, instead of
+                        minimizing (default: False)  .. _Adam\: A Method for
+                        Stochastic Optimization:
+
+Generated arguments for function AdamW:
+  Implements AdamW algorithm.
+
+  --AdamW.lr ADAMW.LR   learning rate (default: 1e-3)
+  --AdamW.betas ADAMW.BETAS
+                        coefficients used for computing running averages of gradient
+                        and its square (default: (0.9, 0.999))
+  --AdamW.eps ADAMW.EPS
+                        term added to the denominator to improve numerical stability
+                        (default: 1e-8)
+  --AdamW.weight_decay ADAMW.WEIGHT_DECAY
+                        weight decay coefficient (default: 1e-2)
+  --AdamW.amsgrad       whether to use the AMSGrad variant of this algorithm from
+                        the paper `On the Convergence of Adam and Beyond`_ (default:
+                        False)
+  --AdamW.maximize      maximize the params based on the objective, instead of
+                        minimizing (default: False)  .. _Decoupled Weight Decay
+                        Regularization:
+
+Generated arguments for function Adamax:
+  Implements Adamax algorithm (a variant of Adam based on
+  infinity norm).
+
+  --Adamax.lr ADAMAX.LR
+                        learning rate (default: 2e-3)
+  --Adamax.betas ADAMAX.BETAS
+                        coefficients used for computing running averages of gradient
+                        and its square
+  --Adamax.eps ADAMAX.EPS
+                        term added to the denominator to improve numerical stability
+                        (default: 1e-8)
+  --Adamax.weight_decay ADAMAX.WEIGHT_DECAY
+                        weight decay (L2 penalty) (default: 0) .. _Adam\: A Method
+                        for Stochastic Optimization:
+
+Generated arguments for function LBFGS:
+  Implements L-BFGS algorithm, heavily inspired by `minFunc
+
+  --LBFGS.lr LBFGS.LR   learning rate (default: 1)
+  --LBFGS.max_iter LBFGS.MAX_ITER
+                        maximal number of iterations per optimization step (default:
+                        20)
+  --LBFGS.max_eval LBFGS.MAX_EVAL
+                        maximal number of function evaluations per optimization step
+                        (default: max_iter * 1.25).
+  --LBFGS.tolerance_grad LBFGS.TOLERANCE_GRAD
+                        termination tolerance on first order optimality (default:
+                        1e-5).
+  --LBFGS.tolerance_change LBFGS.TOLERANCE_CHANGE
+                        termination tolerance on function value/parameter changes
+                        (default: 1e-9).
+  --LBFGS.history_size LBFGS.HISTORY_SIZE
+                        update history size (default: 100).
+  --LBFGS.line_search_fn LBFGS.LINE_SEARCH_FN
+                        either 'strong_wolfe' or None (default: None).
+
+Generated arguments for function NAdam:
+  Implements NAdam algorithm.
+
+  --NAdam.lr NADAM.LR   learning rate (default: 2e-3)
+  --NAdam.betas NADAM.BETAS
+                        coefficients used for computing running averages of gradient
+                        and its square (default: (0.9, 0.999))
+  --NAdam.eps NADAM.EPS
+                        term added to the denominator to improve numerical stability
+                        (default: 1e-8)
+  --NAdam.weight_decay NADAM.WEIGHT_DECAY
+                        weight decay (L2 penalty) (default: 0)
+  --NAdam.momentum_decay NADAM.MOMENTUM_DECAY
+                        momentum momentum_decay (default: 4e-3) .. _Incorporating
+                        Nesterov Momentum into Adam:
+
+Generated arguments for function Optimizer:
+  Base class for all optimizers.
+
+Generated arguments for function RAdam:
+  Implements RAdam algorithm.
+
+  --RAdam.lr RADAM.LR   learning rate (default: 1e-3)
+  --RAdam.betas RADAM.BETAS
+                        coefficients used for computing running averages of gradient
+                        and its square (default: (0.9, 0.999))
+  --RAdam.eps RADAM.EPS
+                        term added to the denominator to improve numerical stability
+                        (default: 1e-8)
+  --RAdam.weight_decay RADAM.WEIGHT_DECAY
+                        weight decay (L2 penalty) (default: 0) .. _On the variance
+                        of the adaptive learning rate and beyond:
+
+Generated arguments for function RMSprop:
+  Implements RMSprop algorithm.
+
+  --RMSprop.lr RMSPROP.LR
+                        learning rate (default: 1e-2)
+  --RMSprop.alpha RMSPROP.ALPHA
+                        smoothing constant (default: 0.99)
+  --RMSprop.eps RMSPROP.EPS
+                        term added to the denominator to improve numerical stability
+                        (default: 1e-8)
+  --RMSprop.weight_decay RMSPROP.WEIGHT_DECAY
+                        weight decay (L2 penalty) (default: 0)
+  --RMSprop.momentum RMSPROP.MOMENTUM
+                        momentum factor (default: 0)
+  --RMSprop.centered    if ``True``, compute the centered RMSProp, the gradient is
+                        normalized by an estimation of its variance
+
+Generated arguments for function Rprop:
+  Implements the resilient backpropagation algorithm.
+
+  --Rprop.lr RPROP.LR   learning rate (default: 1e-2)
+  --Rprop.etas RPROP.ETAS
+                        pair of (etaminus, etaplis), that are multiplicative
+                        increase and decrease factors (default: (0.5, 1.2))
+  --Rprop.step_sizes RPROP.STEP_SIZES
+                        a pair of minimal and maximal allowed step sizes (default:
+                        (1e-6, 50))
+
+Generated arguments for function SGD:
+  Implements stochastic gradient descent (optionally with
+  momentum).
+
+  --SGD.lr SGD.LR       learning rate
+  --SGD.momentum SGD.MOMENTUM
+                        momentum factor (default: 0)
+  --SGD.dampening SGD.DAMPENING
+                        dampening for momentum (default: 0)
+  --SGD.weight_decay SGD.WEIGHT_DECAY
+                        weight decay (L2 penalty) (default: 0)
+  --SGD.nesterov        enables Nesterov momentum (default: False)
+  --SGD.maximize        maximize the params based on the objective, instead of
+                        minimizing (default: False)
+
+Generated arguments for function SparseAdam:
+  Implements lazy version of Adam algorithm suitable for
+  sparse tensors.
+
+  --SparseAdam.lr SPARSEADAM.LR
+                        learning rate (default: 1e-3)
+  --SparseAdam.betas SPARSEADAM.BETAS
+                        coefficients used for computing running averages of gradient
+                        and its square (default: (0.9, 0.999))
+  --SparseAdam.eps SPARSEADAM.EPS
+                        term added to the denominator to improve numerical stability
+                        (default: 1e-8)  .. _Adam\: A Method for Stochastic
+                        Optimization:

--- a/tests/regression/bind_module/bind_module.py.help
+++ b/tests/regression/bind_module/bind_module.py.help
@@ -1,0 +1,39 @@
+ASGD(
+  lr : float = 0.0002
+)
+Adadelta(
+  lr : float = 0.0002
+)
+Adagrad(
+  lr : float = 0.0002
+)
+Adam(
+  lr : float = 0.0002
+)
+AdamW(
+  lr : float = 0.0002
+)
+Adamax(
+  lr : float = 0.0002
+)
+LBFGS(
+  lr : float = 0.0002
+)
+NAdam(
+  lr : float = 0.0002
+)
+RAdam(
+  lr : float = 0.0002
+)
+RMSprop(
+  lr : float = 0.0002
+)
+Rprop(
+  lr : float = 0.0002
+)
+SGD(
+  lr : float = 0.0002
+)
+SparseAdam(
+  lr : float = 0.0002
+)

--- a/tests/regression/bind_module/bind_module.py.run
+++ b/tests/regression/bind_module/bind_module.py.run
@@ -1,0 +1,39 @@
+ASGD(
+  lr : float = 0.0002
+)
+Adadelta(
+  lr : float = 0.0002
+)
+Adagrad(
+  lr : float = 0.0002
+)
+Adam(
+  lr : float = 0.0002
+)
+AdamW(
+  lr : float = 0.0002
+)
+Adamax(
+  lr : float = 0.0002
+)
+LBFGS(
+  lr : float = 0.0002
+)
+NAdam(
+  lr : float = 0.0002
+)
+RAdam(
+  lr : float = 0.0002
+)
+RMSprop(
+  lr : float = 0.0002
+)
+Rprop(
+  lr : float = 0.0002
+)
+SGD(
+  lr : float = 0.0002
+)
+SparseAdam(
+  lr : float = 0.0002
+)

--- a/tests/regression/bind_module/without_bind_module.py.help
+++ b/tests/regression/bind_module/without_bind_module.py.help
@@ -1,36 +1,251 @@
-ASGD(
-  lr : float = 0.0002
-)
-Adadelta(
-  lr : float = 0.0002
-)
-Adagrad(
-  lr : float = 0.0002
-)
-AdamW(
-  lr : float = 0.0002
-)
-Adamax(
-  lr : float = 0.0002
-)
-LBFGS(
-  lr : float = 0.0002
-)
-NAdam(
-  lr : float = 0.0002
-)
-RAdam(
-  lr : float = 0.0002
-)
-RMSprop(
-  lr : float = 0.0002
-)
-Rprop(
-  lr : float = 0.0002
-)
-SGD(
-  lr : float = 0.0002
-)
-SparseAdam(
-  lr : float = 0.0002
-)
+usage: without_bind_module.py [-h] [--args.save ARGS.SAVE]
+                              [--args.load ARGS.LOAD]
+                              [--args.debug ARGS.DEBUG] [--ASGD.lr ASGD.LR]
+                              [--ASGD.lambd ASGD.LAMBD]
+                              [--ASGD.alpha ASGD.ALPHA] [--ASGD.t0 ASGD.T0]
+                              [--ASGD.weight_decay ASGD.WEIGHT_DECAY]
+                              [--Adadelta.lr ADADELTA.LR]
+                              [--Adadelta.rho ADADELTA.RHO]
+                              [--Adadelta.eps ADADELTA.EPS]
+                              [--Adadelta.weight_decay ADADELTA.WEIGHT_DECAY]
+                              [--Adagrad.lr ADAGRAD.LR]
+                              [--Adagrad.lr_decay ADAGRAD.LR_DECAY]
+                              [--Adagrad.weight_decay ADAGRAD.WEIGHT_DECAY]
+                              [--Adagrad.initial_accumulator_value ADAGRAD.INITIAL_ACCUMULATOR_VALUE]
+                              [--Adagrad.eps ADAGRAD.EPS]
+                              [--AdamW.lr ADAMW.LR]
+                              [--AdamW.betas ADAMW.BETAS]
+                              [--AdamW.eps ADAMW.EPS]
+                              [--AdamW.weight_decay ADAMW.WEIGHT_DECAY]
+                              [--AdamW.amsgrad] [--AdamW.maximize]
+                              [--Adamax.lr ADAMAX.LR]
+                              [--Adamax.betas ADAMAX.BETAS]
+                              [--Adamax.eps ADAMAX.EPS]
+                              [--Adamax.weight_decay ADAMAX.WEIGHT_DECAY]
+                              [--LBFGS.lr LBFGS.LR]
+                              [--LBFGS.max_iter LBFGS.MAX_ITER]
+                              [--LBFGS.max_eval LBFGS.MAX_EVAL]
+                              [--LBFGS.tolerance_grad LBFGS.TOLERANCE_GRAD]
+                              [--LBFGS.tolerance_change LBFGS.TOLERANCE_CHANGE]
+                              [--LBFGS.history_size LBFGS.HISTORY_SIZE]
+                              [--LBFGS.line_search_fn LBFGS.LINE_SEARCH_FN]
+                              [--NAdam.lr NADAM.LR]
+                              [--NAdam.betas NADAM.BETAS]
+                              [--NAdam.eps NADAM.EPS]
+                              [--NAdam.weight_decay NADAM.WEIGHT_DECAY]
+                              [--NAdam.momentum_decay NADAM.MOMENTUM_DECAY]
+                              [--RAdam.lr RADAM.LR]
+                              [--RAdam.betas RADAM.BETAS]
+                              [--RAdam.eps RADAM.EPS]
+                              [--RAdam.weight_decay RADAM.WEIGHT_DECAY]
+                              [--RMSprop.lr RMSPROP.LR]
+                              [--RMSprop.alpha RMSPROP.ALPHA]
+                              [--RMSprop.eps RMSPROP.EPS]
+                              [--RMSprop.weight_decay RMSPROP.WEIGHT_DECAY]
+                              [--RMSprop.momentum RMSPROP.MOMENTUM]
+                              [--RMSprop.centered] [--Rprop.lr RPROP.LR]
+                              [--Rprop.etas RPROP.ETAS]
+                              [--Rprop.step_sizes RPROP.STEP_SIZES]
+                              [--SGD.lr SGD.LR] [--SGD.momentum SGD.MOMENTUM]
+                              [--SGD.dampening SGD.DAMPENING]
+                              [--SGD.weight_decay SGD.WEIGHT_DECAY]
+                              [--SGD.nesterov] [--SGD.maximize]
+                              [--SparseAdam.lr SPARSEADAM.LR]
+                              [--SparseAdam.betas SPARSEADAM.BETAS]
+                              [--SparseAdam.eps SPARSEADAM.EPS]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --args.save ARGS.SAVE
+                        Path to save all arguments used to run script to.
+  --args.load ARGS.LOAD
+                        Path to load arguments from, stored as a .yml file.
+  --args.debug ARGS.DEBUG
+                        Print arguments as they are passed to each function.
+
+Generated arguments for function ASGD:
+  Implements Averaged Stochastic Gradient Descent.
+
+  --ASGD.lr ASGD.LR     learning rate (default: 1e-2)
+  --ASGD.lambd ASGD.LAMBD
+                        decay term (default: 1e-4)
+  --ASGD.alpha ASGD.ALPHA
+                        power for eta update (default: 0.75)
+  --ASGD.t0 ASGD.T0     point at which to start averaging (default: 1e6)
+  --ASGD.weight_decay ASGD.WEIGHT_DECAY
+                        weight decay (L2 penalty) (default: 0) .. _Acceleration of
+                        stochastic approximation by averaging:
+
+Generated arguments for function Adadelta:
+  Implements Adadelta algorithm.
+
+  --Adadelta.lr ADADELTA.LR
+                        coefficient that scale delta before it is applied to the
+                        parameters (default: 1.0)
+  --Adadelta.rho ADADELTA.RHO
+                        coefficient used for computing a running average of squared
+                        gradients (default: 0.9)
+  --Adadelta.eps ADADELTA.EPS
+                        term added to the denominator to improve numerical stability
+                        (default: 1e-6)
+  --Adadelta.weight_decay ADADELTA.WEIGHT_DECAY
+                        weight decay (L2 penalty) (default: 0) .. _ADADELTA\: An
+                        Adaptive Learning Rate Method:
+
+Generated arguments for function Adagrad:
+  Implements Adagrad algorithm.
+
+  --Adagrad.lr ADAGRAD.LR
+                        learning rate (default: 1e-2)
+  --Adagrad.lr_decay ADAGRAD.LR_DECAY
+                        learning rate decay (default: 0)
+  --Adagrad.weight_decay ADAGRAD.WEIGHT_DECAY
+                        weight decay (L2 penalty) (default: 0)
+  --Adagrad.initial_accumulator_value ADAGRAD.INITIAL_ACCUMULATOR_VALUE
+  --Adagrad.eps ADAGRAD.EPS
+                        term added to the denominator to improve numerical stability
+                        (default: 1e-10)  .. _Adaptive Subgradient Methods for
+                        Online Learning and Stochastic
+
+Generated arguments for function AdamW:
+  Implements AdamW algorithm.
+
+  --AdamW.lr ADAMW.LR   learning rate (default: 1e-3)
+  --AdamW.betas ADAMW.BETAS
+                        coefficients used for computing running averages of gradient
+                        and its square (default: (0.9, 0.999))
+  --AdamW.eps ADAMW.EPS
+                        term added to the denominator to improve numerical stability
+                        (default: 1e-8)
+  --AdamW.weight_decay ADAMW.WEIGHT_DECAY
+                        weight decay coefficient (default: 1e-2)
+  --AdamW.amsgrad       whether to use the AMSGrad variant of this algorithm from
+                        the paper `On the Convergence of Adam and Beyond`_ (default:
+                        False)
+  --AdamW.maximize      maximize the params based on the objective, instead of
+                        minimizing (default: False)  .. _Decoupled Weight Decay
+                        Regularization:
+
+Generated arguments for function Adamax:
+  Implements Adamax algorithm (a variant of Adam based on
+  infinity norm).
+
+  --Adamax.lr ADAMAX.LR
+                        learning rate (default: 2e-3)
+  --Adamax.betas ADAMAX.BETAS
+                        coefficients used for computing running averages of gradient
+                        and its square
+  --Adamax.eps ADAMAX.EPS
+                        term added to the denominator to improve numerical stability
+                        (default: 1e-8)
+  --Adamax.weight_decay ADAMAX.WEIGHT_DECAY
+                        weight decay (L2 penalty) (default: 0) .. _Adam\: A Method
+                        for Stochastic Optimization:
+
+Generated arguments for function LBFGS:
+  Implements L-BFGS algorithm, heavily inspired by `minFunc
+
+  --LBFGS.lr LBFGS.LR   learning rate (default: 1)
+  --LBFGS.max_iter LBFGS.MAX_ITER
+                        maximal number of iterations per optimization step (default:
+                        20)
+  --LBFGS.max_eval LBFGS.MAX_EVAL
+                        maximal number of function evaluations per optimization step
+                        (default: max_iter * 1.25).
+  --LBFGS.tolerance_grad LBFGS.TOLERANCE_GRAD
+                        termination tolerance on first order optimality (default:
+                        1e-5).
+  --LBFGS.tolerance_change LBFGS.TOLERANCE_CHANGE
+                        termination tolerance on function value/parameter changes
+                        (default: 1e-9).
+  --LBFGS.history_size LBFGS.HISTORY_SIZE
+                        update history size (default: 100).
+  --LBFGS.line_search_fn LBFGS.LINE_SEARCH_FN
+                        either 'strong_wolfe' or None (default: None).
+
+Generated arguments for function NAdam:
+  Implements NAdam algorithm.
+
+  --NAdam.lr NADAM.LR   learning rate (default: 2e-3)
+  --NAdam.betas NADAM.BETAS
+                        coefficients used for computing running averages of gradient
+                        and its square (default: (0.9, 0.999))
+  --NAdam.eps NADAM.EPS
+                        term added to the denominator to improve numerical stability
+                        (default: 1e-8)
+  --NAdam.weight_decay NADAM.WEIGHT_DECAY
+                        weight decay (L2 penalty) (default: 0)
+  --NAdam.momentum_decay NADAM.MOMENTUM_DECAY
+                        momentum momentum_decay (default: 4e-3) .. _Incorporating
+                        Nesterov Momentum into Adam:
+
+Generated arguments for function RAdam:
+  Implements RAdam algorithm.
+
+  --RAdam.lr RADAM.LR   learning rate (default: 1e-3)
+  --RAdam.betas RADAM.BETAS
+                        coefficients used for computing running averages of gradient
+                        and its square (default: (0.9, 0.999))
+  --RAdam.eps RADAM.EPS
+                        term added to the denominator to improve numerical stability
+                        (default: 1e-8)
+  --RAdam.weight_decay RADAM.WEIGHT_DECAY
+                        weight decay (L2 penalty) (default: 0) .. _On the variance
+                        of the adaptive learning rate and beyond:
+
+Generated arguments for function RMSprop:
+  Implements RMSprop algorithm.
+
+  --RMSprop.lr RMSPROP.LR
+                        learning rate (default: 1e-2)
+  --RMSprop.alpha RMSPROP.ALPHA
+                        smoothing constant (default: 0.99)
+  --RMSprop.eps RMSPROP.EPS
+                        term added to the denominator to improve numerical stability
+                        (default: 1e-8)
+  --RMSprop.weight_decay RMSPROP.WEIGHT_DECAY
+                        weight decay (L2 penalty) (default: 0)
+  --RMSprop.momentum RMSPROP.MOMENTUM
+                        momentum factor (default: 0)
+  --RMSprop.centered    if ``True``, compute the centered RMSProp, the gradient is
+                        normalized by an estimation of its variance
+
+Generated arguments for function Rprop:
+  Implements the resilient backpropagation algorithm.
+
+  --Rprop.lr RPROP.LR   learning rate (default: 1e-2)
+  --Rprop.etas RPROP.ETAS
+                        pair of (etaminus, etaplis), that are multiplicative
+                        increase and decrease factors (default: (0.5, 1.2))
+  --Rprop.step_sizes RPROP.STEP_SIZES
+                        a pair of minimal and maximal allowed step sizes (default:
+                        (1e-6, 50))
+
+Generated arguments for function SGD:
+  Implements stochastic gradient descent (optionally with
+  momentum).
+
+  --SGD.lr SGD.LR       learning rate
+  --SGD.momentum SGD.MOMENTUM
+                        momentum factor (default: 0)
+  --SGD.dampening SGD.DAMPENING
+                        dampening for momentum (default: 0)
+  --SGD.weight_decay SGD.WEIGHT_DECAY
+                        weight decay (L2 penalty) (default: 0)
+  --SGD.nesterov        enables Nesterov momentum (default: False)
+  --SGD.maximize        maximize the params based on the objective, instead of
+                        minimizing (default: False)
+
+Generated arguments for function SparseAdam:
+  Implements lazy version of Adam algorithm suitable for
+  sparse tensors.
+
+  --SparseAdam.lr SPARSEADAM.LR
+                        learning rate (default: 1e-3)
+  --SparseAdam.betas SPARSEADAM.BETAS
+                        coefficients used for computing running averages of gradient
+                        and its square (default: (0.9, 0.999))
+  --SparseAdam.eps SPARSEADAM.EPS
+                        term added to the denominator to improve numerical stability
+                        (default: 1e-8)  .. _Adam\: A Method for Stochastic
+                        Optimization:

--- a/tests/regression/bind_module/without_bind_module.py.help
+++ b/tests/regression/bind_module/without_bind_module.py.help
@@ -1,0 +1,36 @@
+ASGD(
+  lr : float = 0.0002
+)
+Adadelta(
+  lr : float = 0.0002
+)
+Adagrad(
+  lr : float = 0.0002
+)
+AdamW(
+  lr : float = 0.0002
+)
+Adamax(
+  lr : float = 0.0002
+)
+LBFGS(
+  lr : float = 0.0002
+)
+NAdam(
+  lr : float = 0.0002
+)
+RAdam(
+  lr : float = 0.0002
+)
+RMSprop(
+  lr : float = 0.0002
+)
+Rprop(
+  lr : float = 0.0002
+)
+SGD(
+  lr : float = 0.0002
+)
+SparseAdam(
+  lr : float = 0.0002
+)

--- a/tests/regression/bind_module/without_bind_module.py.run
+++ b/tests/regression/bind_module/without_bind_module.py.run
@@ -1,0 +1,36 @@
+ASGD(
+  lr : float = 0.0002
+)
+Adadelta(
+  lr : float = 0.0002
+)
+Adagrad(
+  lr : float = 0.0002
+)
+AdamW(
+  lr : float = 0.0002
+)
+Adamax(
+  lr : float = 0.0002
+)
+LBFGS(
+  lr : float = 0.0002
+)
+NAdam(
+  lr : float = 0.0002
+)
+RAdam(
+  lr : float = 0.0002
+)
+RMSprop(
+  lr : float = 0.0002
+)
+Rprop(
+  lr : float = 0.0002
+)
+SGD(
+  lr : float = 0.0002
+)
+SparseAdam(
+  lr : float = 0.0002
+)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -36,7 +36,10 @@ def test_example(path):
     
     _path = path.split('examples/')[-1] + '.help'
     output_path = regression_path / _path
-    check(output, output_path)
+    # Ignore the bind_module ones for help text, as the PyTorch docstrings
+    # might change on us, causing tests to fail.
+    if "bind_module" not in path:
+        check(output, output_path)
 
     # Execute it
     add_args = []


### PR DESCRIPTION
This PR adds a new feature that lets you bind an entire module and its functions. It also removes the requirement for keyword arguments to be typed as long as the type required can be inferred from the default value.