### PR TITLE
Better way for wrapping classes.

### DIFF
--- a/examples/bind_class/README.md
+++ b/examples/bind_class/README.md
@@ -1,0 +1,87 @@
+# Binding classes
+
+## Binding only the init
+
+You can keep a class entirely intact by binding only the init of the class, like so:
+
+```python
+class Example:
+    @argbind.bind()
+    def __init__(self, x: int = 4):
+        pass
+```
+
+`__init__` is special cased inside of ArgBind so that the prefix is the class name, instead of `__init__`. The usage for the above looks like this:
+
+```
+❯ python examples/bind_init_of_class/bind_init_only.py -h
+usage: bind_init_only.py [-h] [--args.save ARGS.SAVE] [--args.load ARGS.LOAD] [--args.debug ARGS.DEBUG]
+                         [--Example.x EXAMPLE.X]
+```
+
+You can also bind methods within a class, and their prefixes will include the class name, like so:
+
+```python
+class Example:
+    @argbind.bind()
+    def __init__(self, x: int = 4):
+        pass
+
+    @classmethod
+    @argbind.bind()
+    def some_class_method(cls, y: int = 2):
+        pass
+```
+
+The usage for the above looks like:
+
+```
+❯ python examples/bind_init_of_class/bind_init_only.py -h
+usage: bind_init_only.py [-h] [--args.save ARGS.SAVE] [--args.load ARGS.LOAD] [--args.debug ARGS.DEBUG]
+                         [--Example.x EXAMPLE.X]
+                         [--Example.some_class_method.y EXAMPLE.SOME_CLASS_METHOD.Y]
+```
+
+## Modifying the class `__init__` function
+
+If you bind a class like so:
+
+```python
+@argbind.bind()
+class Example:
+    def __init__(self, x: int = 4):
+        pass
+
+    @classmethod
+    def some_class_method(cls):
+        pass
+```
+
+The following operations take place:
+
+1. An argbound version of the class's init function is created:
+
+```python
+class_init = getattr(obj, "__init__")
+new_init = argbind.bind(class_init)
+```
+
+2. The class's init function is set to this new argbound init:
+
+```python
+setattr(obj, "__init__", new_init)
+```
+
+3. The modified class is returned:
+
+```python
+return obj
+```
+
+This object now behaves just like the original class, but its arguments are bound! You can do all of this after the fact as well, like so:
+
+```python
+Example = argbind.bind(Example)
+# The class method still exists!
+Example.some_class_method()
+```

--- a/examples/bind_class/bind_class.py
+++ b/examples/bind_class/bind_class.py
@@ -1,0 +1,21 @@
+from ast import arg
+import argbind
+
+@argbind.bind()
+class Example:
+    def __init__(self, x: int = 4):
+        pass
+
+    @classmethod
+    @argbind.bind()
+    def some_class_method(cls, y: int = 2):
+        print("I'm a class method")
+        pass
+
+
+
+if __name__ == "__main__":
+    args = argbind.parse_args()
+    with argbind.scope(args):
+        ex = Example()
+        Example.some_class_method()

--- a/examples/bind_existing/with_argbind.py
+++ b/examples/bind_existing/with_argbind.py
@@ -10,8 +10,16 @@ def my_func(x: int = 100):
 
 if __name__ == "__main__":
     import argbind
+    import pickle
+    import tempfile
+
+    # Create a class that inherits from the original class
+    # so we don't overwrite the original class's init
+    # method. Classes are modified *in place*.
+    class BoundClass(MyClass):
+        pass
     
-    BoundClass = argbind.bind(MyClass, 'pattern')
+    BoundClass = argbind.bind(BoundClass, 'pattern')
     bound_fn = argbind.bind(my_func)
 
     argbind.parse_args() # add for help text, though it isn't used here.
@@ -40,5 +48,9 @@ if __name__ == "__main__":
     # Scoping patterns can be used
     print("Bound objects inside scoping pattern output")
     with argbind.scope(args, 'pattern'):
-        BoundClass() # prints "from binding in scoping pattern"
+        the_class = BoundClass() # prints "from binding in scoping pattern"
         bound_fn() # still prints 123
+
+    with tempfile.NamedTemporaryFile() as f:
+        # Make sure that one can pickle the class.
+        pickle.dump(the_class, f)

--- a/examples/bind_module/bind_module.py
+++ b/examples/bind_module/bind_module.py
@@ -3,7 +3,7 @@ import argbind
 
 optim = argbind.bind_module(
     torch.optim, 
-    filter_fn=lambda fn: hasattr(fn, "step")
+    filter_fn=lambda fn: hasattr(fn, "step") and fn.__name__ != "Optimizer"
 )
 args = {
     "lr": 2e-4,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 setup(
     name='argbind',
-    version='0.3.1', 
+    version='0.3.2', 
     description='Simple way to bind function arguments to the command line.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/regression/bind_class/bind_class.py.help
+++ b/tests/regression/bind_class/bind_class.py.help
@@ -1,0 +1,21 @@
+usage: bind_class.py [-h] [--args.save ARGS.SAVE] [--args.load ARGS.LOAD]
+                     [--args.debug ARGS.DEBUG]
+                     [--Example.some_class_method.y EXAMPLE.SOME_CLASS_METHOD.Y]
+                     [--Example.x EXAMPLE.X]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --args.save ARGS.SAVE
+                        Path to save all arguments used to run script to.
+  --args.load ARGS.LOAD
+                        Path to load arguments from, stored as a .yml file.
+  --args.debug ARGS.DEBUG
+                        Print arguments as they are passed to each function.
+
+Generated arguments for function Example.some_class_method:
+
+  --Example.some_class_method.y EXAMPLE.SOME_CLASS_METHOD.Y
+
+Generated arguments for function Example:
+
+  --Example.x EXAMPLE.X

--- a/tests/regression/bind_class/bind_class.py.run
+++ b/tests/regression/bind_class/bind_class.py.run
@@ -1,0 +1,7 @@
+Example(
+  x : int = 4
+)
+Example.some_class_method(
+  y : int = 2
+)
+I'm a class method


### PR DESCRIPTION
This PR makes it so that when classes are bound by ArgBind, a modified version of the class is returned, rather than turning the class into a function that is argbound, which is what happened before. When binding a class before, the output of `argbind.bind` was a bound version of the class's `__init__` function, which meant that things like classmethods etc were not longer accessible. Now, ArgBind detects if it's being asked to bind a class, and if it is, it replaces its `__init__` function with the argbound version of the init function.

Alternatively, you can bind the `__init__` function directly, and ArgBind will make sure the prefix is the name of the class, rather than `__init__`. Class methods can also be bound, and their arguments will be bound to `ClassName.class_method_name.argument_name` on the command line.

The only catch is that the modification of the class happens *in-place*. You can make sure the original class stays unmodified by doing:

```python
class BoundClass(OriginalClass):
  pass

bound_class argbind.bind(BoundClass)
# OriginalClass will be untouched

argbind.bind(OriginalClass)
# OriginalClass will be modified!
```

Addresses #4.