### PR TITLE
Nesting YAML files now works.

### DIFF
--- a/argbind/argbind.py
+++ b/argbind/argbind.py
@@ -242,9 +242,7 @@ def load_args(input_path_or_stream):
         include_files = data.pop('$include')
         include_args = {}
         for include_file in include_files:
-            with open(include_file, 'r') as f:
-                _include_args = yaml.load(f, Loader=yaml.Loader)
-            include_args.update(_include_args)
+            include_args.update(load_args(include_file))
         include_args.update(data)
         data = include_args
 

--- a/examples/nested_yaml/conf/base.yml
+++ b/examples/nested_yaml/conf/base.yml
@@ -1,0 +1,4 @@
+func.arg1: from base
+func.arg2: from base
+func.arg3: from base
+func.arg4: from base

--- a/examples/nested_yaml/conf/exp.yml
+++ b/examples/nested_yaml/conf/exp.yml
@@ -1,0 +1,3 @@
+$include:
+  - examples/nested_yaml/conf/base.yml
+func.arg4: from exp

--- a/examples/nested_yaml/conf/nested.yml
+++ b/examples/nested_yaml/conf/nested.yml
@@ -1,0 +1,3 @@
+$include:
+  - examples/nested_yaml/conf/exp.yml
+func.arg3: from nested

--- a/examples/nested_yaml/main.py
+++ b/examples/nested_yaml/main.py
@@ -1,0 +1,33 @@
+import argbind
+
+@argbind.bind()
+def func(
+    arg1 : str = 'default',
+    arg2 : str = 'default',
+    arg3 : str = 'default',
+    arg4 : str = 'default',
+):
+    """Dummy function for binding.
+
+    Parameters
+    ----------
+    arg1 : str, optional
+        Argument 1, by default 'default'
+    arg2 : str, optional
+        Argument 2, by default 'default'
+    arg3 : str, optional
+        Argument 3, by default 'default'
+    arg4 : str, optional
+        Argument 4, by default 'default'
+    """
+    print(
+        f"Argument 1: {arg1}\n"
+        f"Argument 2: {arg2}\n"
+        f"Argument 3: {arg3}\n"
+        f"Argument 4: {arg4}\n"
+    )
+
+if __name__ == "__main__":
+    args = argbind.parse_args()
+    with argbind.scope(args):
+        func()

--- a/examples/yaml/README.md
+++ b/examples/yaml/README.md
@@ -29,7 +29,9 @@ Multiple files can be included by putting more items in the list.
 
 If the files in 
 the list also have `$include` directives in their contents, those `$include` 
-directives will not be parsed. **That is to say, this is NOT recursive.**
+directives will also be parsed, allowing you to maintain a hierarchy
+of configuration files as needed, without excessively long `$include`
+sections.
 
 This allows one to share a base configuration between multiple files. You can
 override something inside the base without any issues as well. For example,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 setup(
     name='argbind',
-    version='0.3.5', 
+    version='0.3.6', 
     description='Simple way to bind function arguments to the command line.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/regression/nested_yaml/main.py.help
+++ b/tests/regression/nested_yaml/main.py.help
@@ -1,0 +1,25 @@
+usage: main.py [-h] [--args.save ARGS.SAVE] [--args.load ARGS.LOAD]
+               [--args.debug ARGS.DEBUG] [--func.arg1 FUNC.ARG1]
+               [--func.arg2 FUNC.ARG2] [--func.arg3 FUNC.ARG3]
+               [--func.arg4 FUNC.ARG4]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --args.save ARGS.SAVE
+                        Path to save all arguments used to run script to.
+  --args.load ARGS.LOAD
+                        Path to load arguments from, stored as a .yml file.
+  --args.debug ARGS.DEBUG
+                        Print arguments as they are passed to each function.
+
+Generated arguments for function func:
+  Dummy function for binding.
+
+  --func.arg1 FUNC.ARG1
+                        Argument 1, by default 'default'
+  --func.arg2 FUNC.ARG2
+                        Argument 2, by default 'default'
+  --func.arg3 FUNC.ARG3
+                        Argument 3, by default 'default'
+  --func.arg4 FUNC.ARG4
+                        Argument 4, by default 'default'

--- a/tests/regression/nested_yaml/main.py.run
+++ b/tests/regression/nested_yaml/main.py.run
@@ -1,0 +1,11 @@
+func(
+  arg1 : str = default
+  arg2 : str = default
+  arg3 : str = default
+  arg4 : str = default
+)
+Argument 1: default
+Argument 2: default
+Argument 3: default
+Argument 4: default
+

--- a/tests/regression/nested_yaml/main.py.run0
+++ b/tests/regression/nested_yaml/main.py.run0
@@ -1,0 +1,5 @@
+Argument 1: from base
+Argument 2: from base
+Argument 3: from nested
+Argument 4: from exp
+

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -89,13 +89,6 @@ def test_example(path):
 
 def test_yaml_example():
     added_args = [
-        '--args.load=examples/yaml/conf/base.yml',
-        '--args.load=examples/yaml/conf/exp1.yml',
-        '--args.load=examples/yaml/conf/exp2.yml',
-        '--args.load=examples/yaml/conf/exp3.yml',
-        '--args.load=examples/yaml/conf/exp4.yml',
-    ]
-    added_args = [
         {'env': {}, 'flags': ['--args.load=examples/yaml/conf/base.yml']},
         {'env': {}, 'flags': ['--args.load=examples/yaml/conf/exp1.yml']},
         {'env': {}, 'flags': ['--args.load=examples/yaml/conf/exp2.yml']},
@@ -117,6 +110,21 @@ def test_yaml_example():
             stderr=subprocess.PIPE,
             env=environ
         )
+        output = output.stdout.decode('utf-8')
+
+        _path = path.split('examples/')[-1] + f'.run{i}'
+        output_path = regression_path / _path
+        check(output, output_path)
+
+def test_nested_yaml_example():
+    added_args = [
+        {"flags": ["--args.load=examples/nested_yaml/conf/nested.yml"]},
+    ]
+
+    path = str(examples_path / 'nested_yaml' / 'main.py')
+    for i, add_arg in enumerate(added_args):      
+        cmd = [f"python", path] + add_arg['flags'] 
+        output = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         output = output.stdout.decode('utf-8')
 
         _path = path.split('examples/')[-1] + f'.run{i}'


### PR DESCRIPTION
Changed a line so that you can nest YAML files, so that `$include` directives propagate up. 

Note that if you do circular imports, they're not detected and you'll just hit a recursion error:

```
RecursionError: maximum recursion depth exceeded while calling a Python object
```