### PR TITLE
Added functionality for groups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ python -m pip install -e .
 - [Example 9: Migrating from ArgParse](./examples/migration)
 - [Example 10: Binding existing functions and classes](./examples/bind_existing)
 - [Example 11: Binding entire modules](./examples/bind_module)
+- [Example 12: Binding functions to specific groups](./examples/groups)
 
 ## Usage
 

--- a/argbind/argbind.py
+++ b/argbind/argbind.py
@@ -315,7 +315,7 @@ class str_to_dict():
 
         return _values
 
-def build_parser(group: Union[list, str] = ["default"]):
+def build_parser(group: Union[list, str] = "default"):
     """Builds the argument parser from all of the bound functions.
 
     Returns
@@ -341,7 +341,7 @@ def build_parser(group: Union[list, str] = ["default"]):
         func, patterns, without_prefix, positional, group_ = PARSE_FUNCS[prefix]
         if group_ not in group:
             continue
-        
+
         sig = inspect.signature(func)
 
         docstring = docstring_parser.parse(func.__doc__)
@@ -437,7 +437,7 @@ def build_parser(group: Union[list, str] = ["default"]):
     
     return p
 
-def parse_args(p=None, group: str = "default"):
+def parse_args(p=None, group: Union[list, str] = "default"):
     """
     Parses the command line and returns a dictionary.
     Builds the argument parser if p is None.

--- a/argbind/argbind.py
+++ b/argbind/argbind.py
@@ -60,7 +60,7 @@ def _format_func_debug(func_name, func_kwargs, scope=None):
     formatted.append(")")
     return '\n'.join(formatted)
 
-def bind(*args, without_prefix=False, positional=False):
+def bind(*args, without_prefix=False, positional=False, group="default"):
     """Binds a functions arguments so that it looks up argument
     values in a dictionary scoped by ArgBind.
 
@@ -110,7 +110,7 @@ def bind(*args, without_prefix=False, positional=False):
         if prefix in PARSE_FUNCS:
             func = PARSE_FUNCS[prefix][0]
         else:
-            PARSE_FUNCS[prefix] = (func, patterns, without_prefix, positional)
+            PARSE_FUNCS[prefix] = (func, patterns, without_prefix, positional, group)
         
         @wraps(func)
         def cmd_func(*args, **kwargs):
@@ -315,7 +315,7 @@ class str_to_dict():
 
         return _values
 
-def build_parser():
+def build_parser(group: str = "default"):
     """Builds the argument parser from all of the bound functions.
 
     Returns
@@ -335,7 +335,7 @@ def build_parser():
         help="Print arguments as they are passed to each function.")
 
     # Add kwargs from function to parser
-    for prefix in PARSE_FUNCS:
+    for prefix in PARSE_FUNCS[group]:
         func, patterns, without_prefix, positional = PARSE_FUNCS[prefix]
         sig = inspect.signature(func)
 
@@ -432,12 +432,12 @@ def build_parser():
     
     return p
 
-def parse_args(p=None):
+def parse_args(p=None, group: str = "default"):
     """
     Parses the command line and returns a dictionary.
     Builds the argument parser if p is None.
     """
-    p = build_parser() if p is None else p
+    p = build_parser(group=group) if p is None else p
     used_args = [x.replace('--', '').split('=')[0] for x in sys.argv if x.startswith('--')]
     used_args.extend(['args.save', 'args.load'])
 

--- a/argbind/argbind.py
+++ b/argbind/argbind.py
@@ -335,8 +335,10 @@ def build_parser(group: str = "default"):
         help="Print arguments as they are passed to each function.")
 
     # Add kwargs from function to parser
-    for prefix in PARSE_FUNCS[group]:
-        func, patterns, without_prefix, positional = PARSE_FUNCS[prefix]
+    for prefix in PARSE_FUNCS:
+        func, patterns, without_prefix, positional, group_ = PARSE_FUNCS[prefix]
+        if group_ != group:
+            continue
         sig = inspect.signature(func)
 
         docstring = docstring_parser.parse(func.__doc__)

--- a/argbind/argbind.py
+++ b/argbind/argbind.py
@@ -1,7 +1,7 @@
 import inspect
 from contextlib import contextmanager
 import argparse
-from typing import List, Dict
+from typing import List, Dict, Union
 import docstring_parser
 import textwrap
 import yaml
@@ -315,7 +315,7 @@ class str_to_dict():
 
         return _values
 
-def build_parser(group: str = "default"):
+def build_parser(group: Union[list, str] = ["default"]):
     """Builds the argument parser from all of the bound functions.
 
     Returns
@@ -334,11 +334,14 @@ def build_parser(group: str = "default"):
     p.add_argument('--args.debug', type=int, required=False, default=0, 
         help="Print arguments as they are passed to each function.")
 
+    if isinstance(group, str):
+        group = [group]
     # Add kwargs from function to parser
     for prefix in PARSE_FUNCS:
         func, patterns, without_prefix, positional, group_ = PARSE_FUNCS[prefix]
-        if group_ != group:
+        if group_ not in group:
             continue
+        
         sig = inspect.signature(func)
 
         docstring = docstring_parser.parse(func.__doc__)

--- a/argbind/argbind.py
+++ b/argbind/argbind.py
@@ -60,7 +60,7 @@ def _format_func_debug(func_name, func_kwargs, scope=None):
     formatted.append(")")
     return '\n'.join(formatted)
 
-def bind(*args, without_prefix=False, positional=False, group="default"):
+def bind(*args, without_prefix=False, positional=False, group: Union[list, str] = "default"):
     """Binds a functions arguments so that it looks up argument
     values in a dictionary scoped by ArgBind.
 
@@ -94,6 +94,8 @@ def bind(*args, without_prefix=False, positional=False, group="default"):
             "See https://github.com/pseeth/argbind/tree/main/examples/hello_world#argbind-with-positional-arguments")
         patterns = []
 
+    if isinstance(group, str):
+        group = [group]
 
     def decorator(object_or_func):
         func = object_or_func
@@ -336,10 +338,12 @@ def build_parser(group: Union[list, str] = "default"):
 
     if isinstance(group, str):
         group = [group]
+    if "default" not in group:
+        group.append("default")
     # Add kwargs from function to parser
     for prefix in PARSE_FUNCS:
-        func, patterns, without_prefix, positional, group_ = PARSE_FUNCS[prefix]
-        if group_ not in group:
+        func, patterns, without_prefix, positional, fn_group = PARSE_FUNCS[prefix]
+        if not set(fn_group) & set(group):
             continue
 
         sig = inspect.signature(func)

--- a/examples/groups/main.py
+++ b/examples/groups/main.py
@@ -5,13 +5,22 @@
 import argbind
 import sys
 
-@argbind.bind(group="prepare")
+# This function is always bound.
+@argbind.bind(without_prefix=True)
+def common(
+    some_arg: str = "test"
+):
+    pass
+
+# This function is bound only when "prepare" is the group.
+@argbind.bind(group="prepare", without_prefix=True)
 def prepare(
     data_dir: str = "/data/"
 ):
     pass
 
-@argbind.bind(group="train")
+# This function is bound only when "train" is the group.
+@argbind.bind(group="train", without_prefix=True)
 def train(
     data_dir: str = "/data/",
     num_epochs: int = 1000,
@@ -19,7 +28,8 @@ def train(
 ):
     pass
 
-@argbind.bind(group="evaluate")
+# This function is bound only when "evaluate" is the group.
+@argbind.bind(group="evaluate", without_prefix=True)
 def evaluate(
     data_dir: str = "/data/",
     save_path: str = "/runs/baseline"

--- a/examples/groups/main.py
+++ b/examples/groups/main.py
@@ -1,0 +1,35 @@
+# Sometimes you want to write a program that contains multiple
+# subcommands, possibly with overlapping command names. To do this,
+# use the "groups" feature of ArgBind.
+
+import argbind
+import sys
+
+@argbind.bind(group="prepare")
+def prepare(
+    data_dir: str = "/data/"
+):
+    pass
+
+@argbind.bind(group="train")
+def train(
+    data_dir: str = "/data/",
+    num_epochs: int = 1000,
+    save_path: str = "/runs/baseline"
+):
+    pass
+
+@argbind.bind(group="evaluate")
+def evaluate(
+    data_dir: str = "/data/",
+    save_path: str = "/runs/baseline"
+):
+    pass
+
+if __name__ == "__main__":
+    group = sys.argv.pop(1)
+    args = argbind.parse_args(group=group)
+    
+    fn = locals().get(group)
+    with argbind.scope(args):
+        fn()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 setup(
     name='argbind',
-    version='0.3.6', 
+    version='0.3.7', 
     description='Simple way to bind function arguments to the command line.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/regression/groups/main.py.help
+++ b/tests/regression/groups/main.py.help
@@ -1,7 +1,6 @@
 usage: main.py [-h] [--args.save ARGS.SAVE] [--args.load ARGS.LOAD]
-               [--args.debug ARGS.DEBUG]
-               [--evaluate.data_dir EVALUATE.DATA_DIR]
-               [--evaluate.save_path EVALUATE.SAVE_PATH]
+               [--args.debug ARGS.DEBUG] [--some_arg SOME_ARG]
+               [--data_dir DATA_DIR] [--save_path SAVE_PATH]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -12,7 +11,11 @@ optional arguments:
   --args.debug ARGS.DEBUG
                         Print arguments as they are passed to each function.
 
+Generated arguments for function common:
+
+  --some_arg SOME_ARG
+
 Generated arguments for function evaluate:
 
-  --evaluate.data_dir EVALUATE.DATA_DIR
-  --evaluate.save_path EVALUATE.SAVE_PATH
+  --data_dir DATA_DIR
+  --save_path SAVE_PATH

--- a/tests/regression/groups/main.py.help
+++ b/tests/regression/groups/main.py.help
@@ -1,0 +1,18 @@
+usage: main.py [-h] [--args.save ARGS.SAVE] [--args.load ARGS.LOAD]
+               [--args.debug ARGS.DEBUG]
+               [--evaluate.data_dir EVALUATE.DATA_DIR]
+               [--evaluate.save_path EVALUATE.SAVE_PATH]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --args.save ARGS.SAVE
+                        Path to save all arguments used to run script to.
+  --args.load ARGS.LOAD
+                        Path to load arguments from, stored as a .yml file.
+  --args.debug ARGS.DEBUG
+                        Print arguments as they are passed to each function.
+
+Generated arguments for function evaluate:
+
+  --evaluate.data_dir EVALUATE.DATA_DIR
+  --evaluate.save_path EVALUATE.SAVE_PATH

--- a/tests/regression/groups/main.py.run
+++ b/tests/regression/groups/main.py.run
@@ -1,0 +1,5 @@
+train(
+  data_dir : str = /data/
+  num_epochs : int = 1000
+  save_path : str = /runs/baseline
+)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -30,7 +30,11 @@ def check(output, output_path):
 @pytest.mark.parametrize("path", paths)
 def test_example(path):
     # Get help text
-    output = subprocess.run(["python", path, "-h"], 
+    help_args = []
+
+    if "groups" in path:
+        help_args.append("evaluate")
+    output = subprocess.run(["python", path] + help_args + ["-h"], 
         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output = output.stdout.decode('utf-8')
     
@@ -40,7 +44,7 @@ def test_example(path):
     # might change on us, causing tests to fail.
     if "bind_module" not in path:
         check(output, output_path)
-
+    
     # Execute it
     add_args = []
     if 'argparse' not in path:
@@ -58,6 +62,8 @@ def test_example(path):
         add_args.append("1")
     if "add_to_parser"in path:
         add_args.extend(["test", "test", "test"])
+    if "groups" in path:
+        add_args.append("train")
 
     output = subprocess.run(["python", path] + add_args, 
         stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -47,6 +47,9 @@ def test_example(path):
     
     # Execute it
     add_args = []
+    if "groups" in path:
+        add_args.append("train")
+        
     if 'argparse' not in path:
         add_args.append("--args.debug=1")
         if 'mnist' in path:
@@ -62,9 +65,9 @@ def test_example(path):
         add_args.append("1")
     if "add_to_parser"in path:
         add_args.extend(["test", "test", "test"])
-    if "groups" in path:
-        add_args.append("train")
+    
 
+    print(f"python {path} " + " ".join(add_args))
     output = subprocess.run(["python", path] + add_args, 
         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output = output.stdout.decode('utf-8')


### PR DESCRIPTION
Some binds can now be turned off by assigning the functions to specific groups. Looks like this:

```python
# Sometimes you want to write a program that contains multiple
# subcommands, possibly with overlapping command names. To do this,
# use the "groups" feature of ArgBind.

import argbind
import sys

# This function is always bound.
@argbind.bind(without_prefix=True)
def common(
    some_arg: str = "test"
):
    pass

# This function is bound only when "prepare" is the group.
@argbind.bind(group="prepare", without_prefix=True)
def prepare(
    data_dir: str = "/data/"
):
    pass

# This function is bound only when "train" is the group.
@argbind.bind(group="train", without_prefix=True)
def train(
    data_dir: str = "/data/",
    num_epochs: int = 1000,
    save_path: str = "/runs/baseline"
):
    pass

# This function is bound only when "evaluate" is the group.
@argbind.bind(group="evaluate", without_prefix=True)
def evaluate(
    data_dir: str = "/data/",
    save_path: str = "/runs/baseline"
):
    pass

if __name__ == "__main__":
    group = sys.argv.pop(1)
    args = argbind.parse_args(group=group)
    
    fn = locals().get(group)
    with argbind.scope(args):
        fn()
```

And you can use it like so 

```bash
~/research/argbind ps/groups !5 ❯ python examples/groups/main.py train -h                                                                                                                              29s 🐍 argbind
usage: main.py [-h] [--args.save ARGS.SAVE] [--args.load ARGS.LOAD] [--args.debug ARGS.DEBUG] [--some_arg SOME_ARG] [--data_dir DATA_DIR] [--num_epochs NUM_EPOCHS] [--save_path SAVE_PATH]

optional arguments:
  -h, --help            show this help message and exit
  --args.save ARGS.SAVE
                        Path to save all arguments used to run script to.
  --args.load ARGS.LOAD
                        Path to load arguments from, stored as a .yml file.
  --args.debug ARGS.DEBUG
                        Print arguments as they are passed to each function.

Generated arguments for function common:

  --some_arg SOME_ARG

Generated arguments for function train:

  --data_dir DATA_DIR
  --num_epochs NUM_EPOCHS
  --save_path SAVE_PATH
```