### PR TITLE
Improve subclass binding when __init__ is not defined.

### DIFF
--- a/argbind/argbind.py
+++ b/argbind/argbind.py
@@ -99,11 +99,18 @@ def bind(*args, without_prefix=False, positional=False, group: Union[list, str] 
 
     def decorator(object_or_func):
         func = object_or_func
+        prefix = func.__qualname__  # get prefix before a potential monkey patch below changes it to a superclass's prefix
         is_class = inspect.isclass(func)
         if is_class:
+            # If the class has no __init__ method, find the __init__ method from the closest superclass
+            # that defines one. Then monkey patch that __init__ onto the class.
+            if '__init__' not in func.__dict__:
+                for base in func.__mro__[1:]:
+                    if '__init__' in base.__dict__:
+                        func.__init__ = base.__init__  # monkey patch
+                        break
             func = getattr(func, "__init__")            
 
-        prefix = func.__qualname__
         if "__init__" in prefix:
             prefix = prefix.split(".")[0]
         

--- a/examples/bind_existing/with_argbind.py
+++ b/examples/bind_existing/with_argbind.py
@@ -25,8 +25,8 @@ if __name__ == "__main__":
     argbind.parse_args() # add for help text, though it isn't used here.
 
     args = {
-      'MyClass.x': 'from binding',
-      'pattern/MyClass.x': 'from binding in scoping pattern',
+      'BoundClass.x': 'from binding',
+      'pattern/BoundClass.x': 'from binding in scoping pattern',
       'my_func.x': 123,
       'args.debug': True # for printing arguments passed to each function
     }

--- a/examples/bind_existing/with_argbind_abstract_classes.py
+++ b/examples/bind_existing/with_argbind_abstract_classes.py
@@ -1,0 +1,42 @@
+import abc
+from typing import Any, Dict
+
+import argbind
+
+
+class Base(abc.ABC):
+  
+    def __init__(self, config: Dict[str, Any] = None):
+        self.config = config
+
+    @abc.abstractmethod
+    def action(self):
+        """Do something"""
+
+
+@argbind.bind()
+class Sub1(Base):
+
+    def action(self):
+        print('hello', self.config)
+
+
+@argbind.bind()
+class Sub2(Base):
+
+    def action(self):
+        print('goodbye', self.config)
+
+
+if __name__ == "__main__":
+
+    argbind.parse_args() # add for help text, though it isn't used here.
+
+    args = {
+      'Sub1.config': {"a": "apple", "b": "banana"},
+      'Sub2.config': {"c": "cherry", "d": "durian"},
+    }
+
+    with argbind.scope(args):
+        Sub1().action() # prints "hello {'a': 'apple', 'b': 'banana'}"
+        Sub2().action() # prints "goodbye {'c': 'cherry', 'd': 'durian'}"


### PR DESCRIPTION
I have a lot of subclasses of an abstract base class. The subclasses all use the the base's `__init__`, and so I don't explicitly write out the `__init__` for each. However, this is causing an issue in argbind when I want to configure the kwargs in the init of each subclass differently. It ends up not configuring the kwargs at all and leaves them at their defaults.

Example of the **current** argbind:

```python
import abc
from typing import Any, Dict

import argbind


class Base(abc.ABC):
  
    def __init__(self, config: Dict[str, Any] = None):
        self.config = config

    @abc.abstractmethod
    def action(self):
        """Do something"""


@argbind.bind()
class Sub1(Base):

    def action(self):
        print('hello', self.config)


@argbind.bind()
class Sub2(Base):

    def action(self):
        print('goodbye', self.config)


if __name__ == "__main__":

    argbind.parse_args() # add for help text, though it isn't used here.

    args = {
      'Sub1.config': {"a": "apple", "b": "banana"},
      'Sub2.config': {"c": "cherry", "d": "durian"},
    }

    with argbind.scope(args):
        Sub1().action() # prints "hello None"
        Sub2().action() # prints "goodbye None"
```

Notice that it didn't pass the requested `config` and instead left it as None.

With this PR, the last section is instead:

```python
    with argbind.scope(args):
        Sub1().action() # prints "hello {'a': 'apple', 'b': 'banana'}"
        Sub2().action() # prints "goodbye {'c': 'cherry', 'd': 'durian'}"
```

I also updated `examples/bind_existing/with_argbind.py` to make more sense to me. It produces the same output as before, but I changed some code. I think it's confusing to put the superclass `MyClass` in the args/yaml. To me, it makes more sense to be able to put the subclass `BoundClass`.